### PR TITLE
WIP: Panoptes client

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,11 +98,12 @@
             return _this.UserStringGetter.getUserID().then(function(data) {
               if (data != null) {
                 if (data !== _this.UserStringGetter.currentUserID) {
-                  return _this.UserStringGetter.currentUserID = data;
+                  _this.UserStringGetter.currentUserID = data;
                 }
               }
-            }).then(function() {
-              eventData['userID'] = _this.UserStringGetter.currentUserID;
+              return _this.UserStringGetter.currentUserID;
+            }).then(function(userID) {
+              eventData['userID'] = userID;
               return resolve(eventData);
             });
           } else {
@@ -121,7 +122,7 @@
               eventData['cohort'] = cohort;
               return _this.experimentServerClient.currentCohort = cohort;
             }
-          }).always(function() {
+          }).then(function() {
             return resolve(eventData);
           });
         };

--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@
       if (config == null) {
         config = {};
       }
+      if (config.server && this.GEORDI_SERVER_URL[config.server]) {
+        config.env = config.server;
+        delete config.server;
+      }
       results = [];
       for (property in config) {
         value = config[property];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "devDependencies": {
     "blue-tape": "~0.1.11",
     "coffee-script": "^1.10.0",
-    "tap-spec": "~4.1.1"
+    "tap-spec": "~4.1.1",
+    "xhr2": "^0.1.3"
   },
   "dependencies": {
     "es6-promise": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,8 @@
     "coffee-script": "^1.10.0",
     "tap-spec": "~4.1.1"
   },
-  "peerDependencies": {
-    "jqueryify": "^1.8.0"
-  },
   "dependencies": {
+    "es6-promise": "^3.2.1",
     "zooniverse-user-string-getter": "^1.1.23"
   },
   "repository": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -40,6 +40,10 @@ module.exports = class GeordiClient
     @UserStringGetter = new ZooUserStringGetter @zooUserIDGetter, @zooUserIDGetterParameter
   
   update: (config = {}) ->
+    if config.server && @GEORDI_SERVER_URL[config.server]
+      config.env = config.server
+      delete config.server
+      
     for property, value of config
       @[property] = value
       

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,47 +3,46 @@ ZooUserStringGetter = require 'zooniverse-user-string-getter'
 
 module.exports = class GeordiClient
 
-  GEORDI_STAGING_SERVER_URL:
-    'https://geordi.staging.zooniverse.org/api/events/'
-  GEORDI_PRODUCTION_SERVER_URL:
-    'https://geordi.zooniverse.org/api/events/'
+  GEORDI_SERVER_URL:
+    staging: 'https://geordi.staging.zooniverse.org/api/events/'
+    production: 'https://geordi.zooniverse.org/api/events/'
+  
+  GEORDI_DATABASE_FIELDS: [
+      "userID"
+      "subjectID"
+      "relatedID"
+      "errorCode"
+      "errorDescription"
+      "projectToken"
+      "serverURL"
+      "experiment"
+      "cohort"
+      "type"
+      "userSeq"
+      "sessionNumber"
+      "eventNumber"
+      "userAgent"
+      "clientIP"
+    ]
 
+  # Default config parameters
   gettingCohort: false
-
-  _defaultSubjectGetter: ->
+  env: 'staging'
+  projectToken: 'unspecified' 
+  subjectGetter: () ->
     "(N/A)"
-
-  _defaultSubjectGetterParameter: ->
-    "(N/A)"
-
-  _defaultLastKnownCohortGetter: ->
+  zooUserIDGetter: () ->
     null
+  zooUserIDGetterParameter: null
 
-  _defaultZooUserIDGetter: ->
-    null
-
-  _defaultProjectToken: "unspecified"
-
-  _getCurrentSubject: @_defaultSubjectGetter
-  _getCurrentUserID: @_defaultZooUserIDGetter
-
-  constructor: (config) ->
-    config["server"] = "staging" if not "server" of config
-    config["projectToken"] = @_defaultProjectToken if (not "projectToken" of config) or (not config["projectToken"] instanceof String) or (not config["projectToken"].length>0)
-    config["zooUserIDGetter"] = @_defaultZooUserIDGetter if (not "zooUserIDGetter" of config) or (not config["zooUserIDGetter"] instanceof Function)
-    config["subjectGetter"] = @_defaultSubjectGetter if (not "subjectGetter" of config) or (not config["subjectGetter"] instanceof Function)
-    config["subjectGetterParameter"] = @_defaultSubjectGetterParameter if (not "subjectGetterParameter" of config)
-    if config["server"] == "production"
-      @GEORDI_SERVER_URL = @GEORDI_PRODUCTION_SERVER_URL
-    else
-      @GEORDI_SERVER_URL = @GEORDI_STAGING_SERVER_URL
-    @experimentServerClient = config["experimentServerClient"] if "experimentServerClient" of config
-    @_getCurrentSubject = config["subjectGetter"]
-    @_getCurrentSubjectParameter = config["subjectGetterParameter"]
-    @_getCurrentUserID = config["zooUserIDGetter"]
-    @_getCurrentUserIDParameter = config["zooUserIDGetterParameter"]
-    @_projectToken = config["projectToken"]
-    @UserStringGetter = new ZooUserStringGetter(@_getCurrentUserID,@_getCurrentUserIDParameter)
+  constructor: (config = {}) ->
+    @update config
+    @UserStringGetter = new ZooUserStringGetter @zooUserIDGetter, @zooUserIDGetterParameter
+  
+  update: (config = {}) ->
+    for property, value of config
+      @[property] = value
+      
 
   ###
   log event with Google Analytics
@@ -66,7 +65,7 @@ module.exports = class GeordiClient
   ###
   _logToGeordi: (eventData) ->
     request = new XMLHttpRequest()
-    request.open "POST", @GEORDI_SERVER_URL
+    request.open "POST", @GEORDI_SERVER_URL[@env]
     request.setRequestHeader "Content-Type", "application/json; charset=utf-8"
     request.send JSON.stringify eventData
 
@@ -81,7 +80,7 @@ module.exports = class GeordiClient
           if data?
             if data!=@UserStringGetter.currentUserID
               @UserStringGetter.currentUserID = data
-        .always =>
+        .then () =>
           eventData['userID'] = @UserStringGetter.currentUserID
           resolve eventData
       else
@@ -98,9 +97,9 @@ module.exports = class GeordiClient
       .always ->
         resolve eventData
 
-  _buildEventData: (eventData = {}) =>
+  _buildEventData: (eventData = {}) ->
     eventData['browserTime'] = Date.now()
-    eventData['projectToken'] = @_projectToken
+    eventData['projectToken'] = @projectToken
     eventData['errorCode'] = ""
     eventData['errorDescription'] = ""
     if @experimentServerClient?
@@ -115,8 +114,8 @@ module.exports = class GeordiClient
 
   _updateEventDataFromParameterObject: (parameterObject, eventData = {}) ->
     # copy all string & numeric data across
-    for field in ["userID","subjectID","relatedID","errorCode","errorDescription","projectToken","serverURL","experiment","cohort","type","userSeq","sessionNumber","eventNumber","userAgent","clientIP"]
-      if field of parameterObject and typeof(parameterObject[field])=="string" and parameterObject[field].length>0
+    for field in @GEORDI_DATABASE_FIELDS
+      if parameterObject[field]? and typeof(parameterObject[field])=="string" and parameterObject[field].length>0
         eventData[field] = parameterObject[field]
     # copy 'data' field across to event data
     if "data" of parameterObject
@@ -140,10 +139,6 @@ module.exports = class GeordiClient
       eventData["browserTime"]=parameterObject["browserTime"]
     eventData
 
-  setProjectToken: (projectTitle) ->
-    projectTitle = @_defaultProjectToken if (not projectTitle instanceof String) or (not projectTitle.length>0)
-    @_projectToken = projectTitle
-
   ###
   This will log a user interaction both in the Geordi
   analytics API and in Google Analytics.
@@ -162,13 +157,13 @@ module.exports = class GeordiClient
       else
         eventData = @_updateEventDataFromParameterObject parameter, eventData
       if not ("subjectID" of eventData and typeof(parameter.subjectID)=="string" and parameter.subjectID.length>0)
-        eventData["subjectID"] = @_getCurrentSubject()
+        eventData["subjectID"] = @subjectGetter()
     else
       eventData["errorCode"] = "GCP02"
       eventData["errorDescription"] = "bad parameter passed to logEvent in Geordi Client"
       eventData["type"] = "error"
     @_addUserDetailsToEventData(eventData)
-    .always (eventData) =>
+    .then (eventData) =>
       if not eventData["userID"]?
         eventData["userID"]=@UserStringGetter.ANONYMOUS
       if (!@experimentServerClient?) || (!@experimentServerClient.shouldGetCohort(eventData["userID"]))
@@ -178,7 +173,7 @@ module.exports = class GeordiClient
         if !@gettingCohort
           @gettingCohort = true
           @_addCohortToEventData(eventData)
-          .always (eventData) =>
+          .then (eventData) =>
             @_logToGeordi eventData
             @_logToGoogle eventData
             @gettingCohort = false

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -80,8 +80,9 @@ module.exports = class GeordiClient
           if data?
             if data!=@UserStringGetter.currentUserID
               @UserStringGetter.currentUserID = data
-        .then () =>
-          eventData['userID'] = @UserStringGetter.currentUserID
+          @UserStringGetter.currentUserID
+        .then ( userID ) ->
+          eventData['userID'] = userID
           resolve eventData
       else
         eventData['userID'] = @UserStringGetter.currentUserID
@@ -94,7 +95,7 @@ module.exports = class GeordiClient
         if cohort?
           eventData['cohort'] = cohort
           @experimentServerClient.currentCohort = cohort
-      .always ->
+      .then () ->
         resolve eventData
 
   _buildEventData: (eventData = {}) ->

--- a/test/index.js
+++ b/test/index.js
@@ -21,3 +21,17 @@ test('Log without a valid project token', function(t) {
       t.end()
     });
 });
+test('Log with valid project token', function(t) {
+  var geordi = new GeordiClient({projectToken: 'test/token'});
+  geordi.logEvent('test event')
+    .then(function(response){
+      t.pass('Valid project token will allow logging');
+      t.end()
+    })
+});
+test('Update data on Geordi', function(t) {
+  var geordi = new GeordiClient({projectToken: 'test/token'});
+  geordi.update({projectToken: 'new/token'})
+  t.equal(geordi.projectToken, 'new/token');
+  t.end()
+});

--- a/test/index.js
+++ b/test/index.js
@@ -29,8 +29,12 @@ test('Log without a valid project token', function(t) {
 test('Log with valid project token', function(t) {
   var geordi = new GeordiClient({projectToken: 'test/token'});
   geordi.logEvent('test event')
-    .then(function(response){
-      t.pass('Valid project token will allow logging');
+    .then(function(data){
+      return JSON.parse(data);
+    })
+    .then(function(event){
+      t.equal(event.projectToken, 'test/token', "correct project token");
+      t.equal(event.type, 'test event', "correct event type");
       t.end();
     })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,8 @@ var test = require('blue-tape');
 var GeordiClient = require('../index');
 
 test('Instantiate a client with default settings', function(t) {
-  var geordi = new GeordiClient({projectToken: ''});
-  t.equal(geordi.GEORDI_SERVER_URL, 'https://geordi.staging.zooniverse.org/api/events/');
-  t.equal(geordi._projectToken, 'unspecified');
+  var geordi = new GeordiClient();
+  t.equal(geordi.env, 'staging');
+  t.equal(geordi.projectToken, 'unspecified');
   t.end()
 });

--- a/test/index.js
+++ b/test/index.js
@@ -7,18 +7,23 @@ test('Instantiate a client with default settings', function(t) {
   var geordi = new GeordiClient();
   t.equal(geordi.env, 'staging');
   t.equal(geordi.projectToken, 'unspecified');
-  t.end()
+  t.end();
+});
+test('Instantiate a client with older settings', function(t) {
+  var geordi = new GeordiClient({server: 'production'});
+  t.equal(geordi.env, 'production');
+  t.end();
 });
 test('Log without a valid project token', function(t) {
   var geordi = new GeordiClient({projectToken:''});
   geordi.logEvent('test event')
     .then(function(response){
       t.fail('invalid project token should not be logged');
-      t.end()
+      t.end();
     })
     .catch(function(error){
       t.pass(error);
-      t.end()
+      t.end();
     });
 });
 test('Log with valid project token', function(t) {
@@ -26,12 +31,12 @@ test('Log with valid project token', function(t) {
   geordi.logEvent('test event')
     .then(function(response){
       t.pass('Valid project token will allow logging');
-      t.end()
+      t.end();
     })
 });
 test('Update data on Geordi', function(t) {
   var geordi = new GeordiClient({projectToken: 'test/token'});
   geordi.update({projectToken: 'new/token'})
   t.equal(geordi.projectToken, 'new/token');
-  t.end()
+  t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+global.XMLHttpRequest = require('xhr2');
+global.dataLayer = [];
 var test = require('blue-tape');
 var GeordiClient = require('../index');
 
@@ -6,4 +8,16 @@ test('Instantiate a client with default settings', function(t) {
   t.equal(geordi.env, 'staging');
   t.equal(geordi.projectToken, 'unspecified');
   t.end()
+});
+test('Log without a valid project token', function(t) {
+  var geordi = new GeordiClient({projectToken:''});
+  geordi.logEvent('test event')
+    .then(function(response){
+      t.fail('invalid project token should not be logged');
+      t.end()
+    })
+    .catch(function(error){
+      t.pass(error);
+      t.end()
+    });
 });


### PR DESCRIPTION
Basically removes jQuery and allows for updating client settings via eg. `client.update( {projectToken: 'my new project'})`.

Makes some pretty major changes to the constructor, so this needs testing.
